### PR TITLE
Fix Uvicorn not listening on 0.0.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ WORKDIR /app
 COPY --from=builder /app .
 
 ENTRYPOINT ["/app/.venv/bin/uvicorn"]
-CMD ["--factory", "apeiron.app:create_app"]
+CMD ["--factory", "apeiron.app:create_app", "--host", "0.0.0.0"]


### PR DESCRIPTION
Stack from [ghstack](https://github.com/ezyang/ghstack) (oldest at bottom):
* (to be filled)

